### PR TITLE
Set Default RuntimeIdentifier to win-x64

### DIFF
--- a/aol_4.sln
+++ b/aol_4.sln
@@ -8,19 +8,13 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4F52B604-4B49-4FEB-BBCA-B7DCA1F4D58F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4F52B604-4B49-4FEB-BBCA-B7DCA1F4D58F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4F52B604-4B49-4FEB-BBCA-B7DCA1F4D58F}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{4F52B604-4B49-4FEB-BBCA-B7DCA1F4D58F}.Debug|x64.Build.0 = Debug|Any CPU
 		{4F52B604-4B49-4FEB-BBCA-B7DCA1F4D58F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F52B604-4B49-4FEB-BBCA-B7DCA1F4D58F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4F52B604-4B49-4FEB-BBCA-B7DCA1F4D58F}.Release|x64.ActiveCfg = Release|x64
-		{4F52B604-4B49-4FEB-BBCA-B7DCA1F4D58F}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/aol_4/aol_4.csproj
+++ b/aol_4/aol_4.csproj
@@ -22,22 +22,16 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <OutputPath>bin\x64\Debug\</OutputPath>
-    <WarningLevel>3</WarningLevel>
-    <NoWarn>CS0108,CS0414</NoWarn>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
+    <PlatformTarget Condition="'$(PlatformTarget)' == ''">x64</PlatformTarget>
+    <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>aol_icon_4_Bnk_icon.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <StartupObject>aol.Forms.Program</StartupObject>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Update="System">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1\System.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
     <Content Include="aol_icon_4_Bnk_icon.ico" />
     <Content Include="Channels\kids.htm">
@@ -95,14 +89,5 @@
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="chromiumembeddedframework.runtime.win-arm64" Version="97.1.6" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="chromiumembeddedframework.runtime.win-x64" Version="97.1.6" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="chromiumembeddedframework.runtime.win-x86" Version="97.1.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- If no runtime identifier set then will default to win-x64
- Remove x64 platform from solution
- Remove .net 4.6.1 system.dll framework reference

This will dramatically reduce the size as as all the other platform dlls won't be included.

If you wish to support x64/x86/arm64 then I'd suggest publishing for each target.
